### PR TITLE
feat(ACI-4362): multiple deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,42 @@ URL of the pull request is exposed as an output in the latter case.
 Updated files are go templates rendered by substituting given values.
 A Github username and Personal Access Token must be provided with access to the repository.
 
+## Multiple deployments mode
+The step supports updating multiple deployment paths in a single commit. This is useful when you need to update several services in the same repository without creating multiple commits.
+
+### Example
+```yaml
+inputs:
+- templates_folder_path: deployments/helm/service
+- deploy_repository_url: https://github.com/bitrise-io/instance-management-deployments.git
+- deploy_branch: production
+- pull_request: false
+- deploy_user: "$DEPLOY_USER"
+- commit_message: "${BITRISE_GIT_MESSAGE}"
+- deployments: |
+    - path: package-foo
+      values:
+        repository: ${GAR_HOST}/${GAR_PROJECT_PRODUCTION}/${GAR_REPOSITORY}/package-foo
+        tag: ${RELEASE_TAG}
+    - path: package-bar
+      values:
+        repository: ${GAR_HOST}/${GAR_PROJECT_PRODUCTION}/${GAR_REPOSITORY}/package-bar
+        tag: ${RELEASE_TAG}
+```
+
+In this example, both services will be updated in a single commit to the GitOps repository.
+
+### Backwards compatibility
+The step maintains full backwards compatibility. You can still use the legacy `deploy_path` and `values` inputs for single deployments:
+
+```yaml
+inputs:
+- deploy_path: my-service
+- values: |
+    repository: example.com/repo/service
+    tag: v1.0.0
+```
+
 ## Replacer mode
 There are situation when simple templating is not sufficient (e.g.: 100 LOC config files). Replacer mode solves this issue by replacing values that match the provided key-delimiter combinations. 
 
@@ -35,6 +71,30 @@ inputs:
       us.gcr.io/ip-kubernetes-dev/hello-world-service: tag2
 ```
 In this case the step will look for maches in `example_config_file.yaml`, where the full path is `$DEPLOY_PATH/example_config_file.yaml`.
+
+### Replacer mode with multiple deployments
+You can also use replacer mode with multiple deployments:
+
+```yaml
+inputs:
+  - deploy_repository_url: $DEPLOY_REPO_URL
+  - pull_request: true
+  - deploy_user: $DEPLOY_USER
+  - deploy_branch: $BRANCH
+  - replacer_mode: true
+  - delimiter: ":"
+  - deployments: |
+      - path: service1
+        files:
+          - config.yaml
+        values:
+          us.gcr.io/ip-kubernetes-dev/service1: tag2
+      - path: service2
+        files:
+          - config.yaml
+        values:
+          us.gcr.io/ip-kubernetes-dev/service2: tag3
+```
 
 ### Caveats
 In Replacer mode, the step matches values up until the first comma, exclamation mark, single quote or double quote.

--- a/README.md
+++ b/README.md
@@ -2,17 +2,16 @@
 
 # Update GitOps repository
 
-## Default mode
 Updates files of a GitOps repository either by pushing changes directly to a
 given folder of a given branch or by opening a pull request to it.
 URL of the pull request is exposed as an output in the latter case.
 Updated files are go templates rendered by substituting given values.
 A Github username and Personal Access Token must be provided with access to the repository.
 
-## Multiple deployments mode
-The step supports updating multiple deployment paths in a single commit. This is useful when you need to update several services in the same repository without creating multiple commits.
+## Usage
 
-### Example
+The step uses the `deployments` input to configure one or more deployment paths to update in a single commit. Each deployment specifies a path in the target repository and the values to apply.
+
 ```yaml
 inputs:
 - templates_folder_path: deployments/helm/service
@@ -32,48 +31,18 @@ inputs:
         tag: ${RELEASE_TAG}
 ```
 
-In this example, both services will be updated in a single commit to the GitOps repository.
-
-### Backwards compatibility
-The step maintains full backwards compatibility. You can still use the legacy `deploy_path` and `values` inputs for single deployments:
-
-```yaml
-inputs:
-- deploy_path: my-service
-- values: |
-    repository: example.com/repo/service
-    tag: v1.0.0
-```
-
 ## Replacer mode
-There are situation when simple templating is not sufficient (e.g.: 100 LOC config files). Replacer mode solves this issue by replacing values that match the provided key-delimiter combinations. 
+
+There are situations when simple templating is not sufficient (e.g.: 100 LOC config files). Replacer mode solves this issue by replacing values that match the provided key-delimiter combinations.
 
 ### Example
-Example:
+
 We have a long config file that has the following line:
 `us.gcr.io/ip-kubernetes-dev/hello-world-service:tag1`
 We would like to replace `tag1` by `tag2` without creating a template.
 We can use the step in "Replacer mode", by defining `us.gcr.io/ip-kubernetes-dev/hello-world-service` as `key`, and `:` as `delimiter`. The step will match & replace `tag1` based on the provided key-delimiter combination.
 
-When `replacer_mode` is enabled, `values` expects input a bit differently. To achieve the desired outcome above of the above example, one could use the following step inputs:
-```yaml
-inputs:
-  - deploy_repository_url: $DEPLOY_REPO_URL
-  - deploy_path: $DEPLOY_PATH
-  - pull_request: true
-  - deploy_user: $DEPLOY_USER
-  - deploy_branch: $BRANCH
-  - replacer_mode: true
-  - delimiter: ":"
-  - files: 
-      - example_config_file.yaml
-  - values: |
-      us.gcr.io/ip-kubernetes-dev/hello-world-service: tag2
-```
-In this case the step will look for maches in `example_config_file.yaml`, where the full path is `$DEPLOY_PATH/example_config_file.yaml`.
-
-### Replacer mode with multiple deployments
-You can also use replacer mode with multiple deployments:
+When `replacer_mode` is enabled, `values` expects input a bit differently. Each deployment must also specify the `files` to scan:
 
 ```yaml
 inputs:
@@ -97,6 +66,7 @@ inputs:
 ```
 
 ### Caveats
+
 In Replacer mode, the step matches values up until the first comma, exclamation mark, single quote or double quote.
 
 # Development

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -48,14 +48,15 @@ workflows:
           title: Test updating files of a GitOps repository
           inputs:
             - deploy_repository_url: $DEPLOY_REPO_URL
-            - deploy_path: $DEPLOY_PATH
             - templates_folder_path: e2e/deployments/helm
             - pull_request: true
             - deploy_user: $DEPLOY_USER
             - deploy_branch: staging
-            - values: |
-                repository: us.gcr.io/ip-kubernetes-dev/hello-world-service
-                tag: test-tag
+            - deployments: |
+                - path: $DEPLOY_PATH
+                  values:
+                    repository: us.gcr.io/ip-kubernetes-dev/hello-world-service
+                    tag: test-tag
       - script:
           inputs:
             - content: |
@@ -65,18 +66,19 @@ workflows:
           title: Test updating matches in a GitOps repository file
           inputs:
             - deploy_repository_url: $DEPLOY_REPO_URL
-            - deploy_path: $DEPLOY_PATH
             - pull_request: true
             - deploy_user: $DEPLOY_USER
             - deploy_branch: staging
             - replacer_mode: true
             - delimiter: ":"
-            - files:
-              - values.yaml
-              - values.ci.yaml
-            - values: |
-                sm: //ip-backstage-dev/backstage-database-password2
-                us.gcr.io/ip-kubernetes-dev/hello-world-service: v6
+            - deployments: |
+                - path: $DEPLOY_PATH
+                  files:
+                    - values.yaml
+                    - values.ci.yaml
+                  values:
+                    sm: //ip-backstage-dev/backstage-database-password2
+                    us.gcr.io/ip-kubernetes-dev/hello-world-service: v6
       - script:
           inputs:
             - content: |

--- a/main.go
+++ b/main.go
@@ -58,13 +58,13 @@ func run() error {
 	}
 
 	if cfg.ReplacerMode {
-		renderer = gitops.MultiReplacer{
+		renderer = gitops.Replacer{
 			Delimiter:       cfg.Delimiter,
 			DestinationRepo: localRepo,
 			Deployments:     cfg.Deployments,
 		}
 	} else {
-		renderer = gitops.MultiTemplates{
+		renderer = gitops.Templates{
 			SourceFolder:    cfg.TemplatesFolder,
 			Deployments:     cfg.Deployments,
 			DestinationRepo: localRepo,

--- a/main.go
+++ b/main.go
@@ -52,22 +52,22 @@ func run() error {
 	defer localRepo.Close(ctx)
 
 	var renderer gitops.AllFilesRenderer
-	// Create templates renderer.
-	renderer = gitops.Templates{
-		SourceFolder:      cfg.TemplatesFolder,
-		Values:            cfg.Values,
-		DestinationRepo:   localRepo,
-		DestinationFolder: cfg.DeployFolder,
+
+	if len(cfg.Deployments) == 0 {
+		return fmt.Errorf("no deployments configured")
 	}
 
 	if cfg.ReplacerMode {
-		// Create templates replacer.
-		renderer = gitops.Replacer{
-			Values:            cfg.Values,
-			Delimiter:         cfg.Delimiter,
-			DestinationRepo:   localRepo,
-			DestinationFolder: cfg.DeployFolder,
-			Files:             cfg.Files,
+		renderer = gitops.MultiReplacer{
+			Delimiter:       cfg.Delimiter,
+			DestinationRepo: localRepo,
+			Deployments:     cfg.Deployments,
+		}
+	} else {
+		renderer = gitops.MultiTemplates{
+			SourceFolder:    cfg.TemplatesFolder,
+			Deployments:     cfg.Deployments,
+			DestinationRepo: localRepo,
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -53,10 +53,6 @@ func run() error {
 
 	var renderer gitops.AllFilesRenderer
 
-	if len(cfg.Deployments) == 0 {
-		return fmt.Errorf("no deployments configured")
-	}
-
 	if cfg.ReplacerMode {
 		renderer = gitops.Replacer{
 			Delimiter:       cfg.Delimiter,

--- a/pkg/gitops/config.go
+++ b/pkg/gitops/config.go
@@ -2,7 +2,6 @@ package gitops
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/bitrise-io/go-steputils/stepconf"
 	"gopkg.in/yaml.v3"
@@ -21,8 +20,6 @@ type Deployment struct {
 type config struct {
 	// DeployRepositoryURL is the URL of the deployment (GitOps) repository.
 	DeployRepositoryURL string `env:"deploy_repository_url,required"`
-	// DeployFolder is the folder to render templates to in the deploy repository (deprecated, use Deployments).
-	DeployFolder string `env:"deploy_path"`
 	// DeployBranch is the branch to render templates to in the deploy repository.
 	DeployBranch string `env:"deploy_branch,required"`
 	// PullRequest won't push to the branch. It will open a PR only instead.
@@ -31,12 +28,8 @@ type config struct {
 	PullRequestTitle string `env:"pull_request_title"`
 	// PullRequestBody is the body of the opened pull request.
 	PullRequestBody string `env:"pull_request_body"`
-	// RawValues are unparsed version of `Values` field (to-be-parsed manually) (deprecated, use Deployments).
-	RawValues string `env:"values"`
-	// Values are values applied to the template files (deprecated, use Deployments).
-	Values map[string]string
 	// RawDeployments are unparsed version of `Deployments` field (to-be-parsed manually).
-	RawDeployments string `env:"deployments"`
+	RawDeployments string `env:"deployments,required"`
 	// Deployments is a list of deployment configurations.
 	Deployments []Deployment
 	// TemplatesFolder is the path to the deployment templates folder.
@@ -51,53 +44,29 @@ type config struct {
 	ReplacerMode bool `env:"replacer_mode,required"`
 	// Delimiter indicates the delimiter between key and value in replacer mode
 	Delimiter string `env:"delimiter"`
-	// RawFiles are unparsed version of `Files` field (to-be-parsed manually) (deprecated, use Deployments).
-	RawFiles string `env:"files"`
-	// Files are required in replacer mode. List of files to find values in for replacement (deprecated, use Deployments).
-	Files []string
 }
 
 func (c config) validate() error {
-	// If using new deployments format
-	if len(c.Deployments) > 0 {
-		for i, deployment := range c.Deployments {
-			if len(deployment.Path) == 0 {
-				return fmt.Errorf("deployment[%d]: path is required", i)
-			}
-			if !c.ReplacerMode && len(c.TemplatesFolder) == 0 {
-				return requiredError("TemplatesFolder")
-			}
-			if c.ReplacerMode {
-				if len(c.Delimiter) == 0 {
-					return requiredError("Delimiter")
-				}
-				if len(deployment.Files) == 0 {
-					return fmt.Errorf("deployment[%d]: files are required in replacer mode", i)
-				}
-			}
-		}
-		return nil
+	if len(c.Deployments) == 0 {
+		return fmt.Errorf("at least one deployment is required")
 	}
 
-	// Legacy single deployment validation
-	if !c.ReplacerMode {
-		if len(c.DeployFolder) == 0 {
-			return requiredError("DeployFolder")
+	for i, deployment := range c.Deployments {
+		if len(deployment.Path) == 0 {
+			return fmt.Errorf("deployment[%d]: path is required", i)
 		}
-
-		if len(c.TemplatesFolder) == 0 {
+		if !c.ReplacerMode && len(c.TemplatesFolder) == 0 {
 			return requiredError("TemplatesFolder")
 		}
-		return nil
+		if c.ReplacerMode {
+			if len(c.Delimiter) == 0 {
+				return requiredError("Delimiter")
+			}
+			if len(deployment.Files) == 0 {
+				return fmt.Errorf("deployment[%d]: files are required in replacer mode", i)
+			}
+		}
 	}
-
-	if len(c.Delimiter) == 0 {
-		return requiredError("Delimiter")
-	}
-	if len(c.Files) == 0 {
-		return requiredError("Files")
-	}
-
 	return nil
 }
 
@@ -108,35 +77,8 @@ func NewConfig() (config, error) {
 		return config{}, fmt.Errorf("parse step config: %w", err)
 	}
 
-	// Parse new deployments format if provided
-	if len(cfg.RawDeployments) > 0 {
-		if err := yaml.Unmarshal([]byte(cfg.RawDeployments), &cfg.Deployments); err != nil {
-			return config{}, fmt.Errorf("parse deployments: %w", err)
-		}
-	} else {
-		// Backwards compatibility: convert legacy format to new format
-		if err := yaml.Unmarshal([]byte(cfg.RawValues), &cfg.Values); err != nil {
-			return config{}, fmt.Errorf("parse values: %w", err)
-		}
-
-		if cfg.ReplacerMode {
-			files, err := parseStringSlice([]byte(cfg.RawFiles), cfg.Files)
-			if err != nil {
-				return config{}, fmt.Errorf("parsing files to string slice: %w", err)
-			}
-			cfg.Files = files
-		}
-
-		// Convert legacy single deployment to new format
-		if len(cfg.DeployFolder) > 0 || len(cfg.Values) > 0 {
-			cfg.Deployments = []Deployment{
-				{
-					Path:   cfg.DeployFolder,
-					Values: cfg.Values,
-					Files:  cfg.Files,
-				},
-			}
-		}
+	if err := yaml.Unmarshal([]byte(cfg.RawDeployments), &cfg.Deployments); err != nil {
+		return config{}, fmt.Errorf("parse deployments: %w", err)
 	}
 
 	if err := cfg.validate(); err != nil {
@@ -148,16 +90,4 @@ func NewConfig() (config, error) {
 
 func requiredError(field string) error {
 	return fmt.Errorf("\n- %s: required variable is not present", field)
-}
-
-func parseStringSlice(raw []byte, field []string) ([]string, error) {
-	if err := yaml.Unmarshal(raw, &field); err != nil {
-		return nil, fmt.Errorf("parse string to string slice: %w", err)
-	}
-	elements := make([]string, 0)
-	for _, s := range field {
-		elements = append(elements, strings.Fields(s)...)
-	}
-
-	return elements, nil
 }

--- a/pkg/gitops/config.go
+++ b/pkg/gitops/config.go
@@ -8,10 +8,20 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Deployment represents a single deployment configuration.
+type Deployment struct {
+	// Path is the folder to render templates to in the deploy repository.
+	Path string `yaml:"path"`
+	// Values are values applied to the template files for this deployment.
+	Values map[string]string `yaml:"values"`
+	// Files are required in replacer mode. List of files to find values in for replacement.
+	Files []string `yaml:"files,omitempty"`
+}
+
 type config struct {
 	// DeployRepositoryURL is the URL of the deployment (GitOps) repository.
 	DeployRepositoryURL string `env:"deploy_repository_url,required"`
-	// DeployFolder is the folder to render templates to in the deploy repository.
+	// DeployFolder is the folder to render templates to in the deploy repository (deprecated, use Deployments).
 	DeployFolder string `env:"deploy_path"`
 	// DeployBranch is the branch to render templates to in the deploy repository.
 	DeployBranch string `env:"deploy_branch,required"`
@@ -21,10 +31,14 @@ type config struct {
 	PullRequestTitle string `env:"pull_request_title"`
 	// PullRequestBody is the body of the opened pull request.
 	PullRequestBody string `env:"pull_request_body"`
-	// RawValues are unparsed version of `Values` field (to-be-parsed manually).
+	// RawValues are unparsed version of `Values` field (to-be-parsed manually) (deprecated, use Deployments).
 	RawValues string `env:"values"`
-	// Values are values applied to the template files.
+	// Values are values applied to the template files (deprecated, use Deployments).
 	Values map[string]string
+	// RawDeployments are unparsed version of `Deployments` field (to-be-parsed manually).
+	RawDeployments string `env:"deployments"`
+	// Deployments is a list of deployment configurations.
+	Deployments []Deployment
 	// TemplatesFolder is the path to the deployment templates folder.
 	TemplatesFolder string `env:"templates_folder_path"`
 	// DeployToken is the Personal Access Token to interact with Github API.
@@ -37,13 +51,35 @@ type config struct {
 	ReplacerMode bool `env:"replacer_mode,required"`
 	// Delimiter indicates the delimiter between key and value in replacer mode
 	Delimiter string `env:"delimiter"`
-	// RawFiles are unparsed version of `Files` field (to-be-parsed manually).
+	// RawFiles are unparsed version of `Files` field (to-be-parsed manually) (deprecated, use Deployments).
 	RawFiles string `env:"files"`
-	// Files are required in replacer mode. List of files to find values in for replacement.
+	// Files are required in replacer mode. List of files to find values in for replacement (deprecated, use Deployments).
 	Files []string
 }
 
 func (c config) validate() error {
+	// If using new deployments format
+	if len(c.Deployments) > 0 {
+		for i, deployment := range c.Deployments {
+			if len(deployment.Path) == 0 {
+				return fmt.Errorf("deployment[%d]: path is required", i)
+			}
+			if !c.ReplacerMode && len(c.TemplatesFolder) == 0 {
+				return requiredError("TemplatesFolder")
+			}
+			if c.ReplacerMode {
+				if len(c.Delimiter) == 0 {
+					return requiredError("Delimiter")
+				}
+				if len(deployment.Files) == 0 {
+					return fmt.Errorf("deployment[%d]: files are required in replacer mode", i)
+				}
+			}
+		}
+		return nil
+	}
+
+	// Legacy single deployment validation
 	if !c.ReplacerMode {
 		if len(c.DeployFolder) == 0 {
 			return requiredError("DeployFolder")
@@ -72,16 +108,35 @@ func NewConfig() (config, error) {
 		return config{}, fmt.Errorf("parse step config: %w", err)
 	}
 
-	if err := yaml.Unmarshal([]byte(cfg.RawValues), &cfg.Values); err != nil {
-		return config{}, fmt.Errorf("parse values: %w", err)
-	}
-
-	if cfg.ReplacerMode {
-		files, err := parseStringSlice([]byte(cfg.RawFiles), cfg.Files)
-		if err != nil {
-			return config{}, fmt.Errorf("parsing files to string slice: %w", err)
+	// Parse new deployments format if provided
+	if len(cfg.RawDeployments) > 0 {
+		if err := yaml.Unmarshal([]byte(cfg.RawDeployments), &cfg.Deployments); err != nil {
+			return config{}, fmt.Errorf("parse deployments: %w", err)
 		}
-		cfg.Files = files
+	} else {
+		// Backwards compatibility: convert legacy format to new format
+		if err := yaml.Unmarshal([]byte(cfg.RawValues), &cfg.Values); err != nil {
+			return config{}, fmt.Errorf("parse values: %w", err)
+		}
+
+		if cfg.ReplacerMode {
+			files, err := parseStringSlice([]byte(cfg.RawFiles), cfg.Files)
+			if err != nil {
+				return config{}, fmt.Errorf("parsing files to string slice: %w", err)
+			}
+			cfg.Files = files
+		}
+
+		// Convert legacy single deployment to new format
+		if len(cfg.DeployFolder) > 0 || len(cfg.Values) > 0 {
+			cfg.Deployments = []Deployment{
+				{
+					Path:   cfg.DeployFolder,
+					Values: cfg.Values,
+					Files:  cfg.Files,
+				},
+			}
+		}
 	}
 
 	if err := cfg.validate(); err != nil {

--- a/pkg/gitops/replacer.go
+++ b/pkg/gitops/replacer.go
@@ -14,76 +14,28 @@ type Replacer struct {
 	Delimiter string
 	// Destination repository for rendered files.
 	DestinationRepo localRepository
-	// Values to substitute into the templates.
-	Values map[string]string
-	// Files to search through for matches
-	Files []string
-	// Destination folder inside the repository for rendered files.
-	DestinationFolder string
-}
-
-// MultiReplacer replaces values in multiple deployment folders.
-type MultiReplacer struct {
-	// Delimiter to look for when rendering key-value pairs
-	Delimiter string
-	// Destination repository for rendered files.
-	DestinationRepo localRepository
 	// Deployments contains multiple deployment configurations.
 	Deployments []Deployment
 }
 
-// Ensure MultiReplacer implements AllFilesRenderer
-var _ AllFilesRenderer = (*MultiReplacer)(nil)
+var _ AllFilesRenderer = (*Replacer)(nil)
 
 func (rp Replacer) renderAllFiles() error {
-	// Replace values in files sitting in the destinaton folder one-by-one
-	// (substituting values given).
-	for _, file := range rp.Files {
-		originalFile := path.Join(rp.DestinationRepo.localPath(), rp.DestinationFolder, file)
-		renderedFile, err := rp.renderFile(originalFile, rp.Values)
-
-		if err != nil {
-			return fmt.Errorf("render file %q: %w", originalFile, err)
-		}
-		defer os.Remove(renderedFile) //nolint:errcheck
-
-		// the rendered / replaced file becomes the source
-		source, err := os.Open(renderedFile)
-		if err != nil {
-			return fmt.Errorf("open rendered file: %w", err)
-		}
-		defer source.Close() //nolint:errcheck
-
-		// the original file location becomes the destionation
-		destination, err := os.Create(originalFile)
-		if err != nil {
-			return fmt.Errorf("open destination file: %w", err)
-		}
-
-		// write the updated file contents to the original location
-		if err := copy(source, destination); err != nil {
-			return fmt.Errorf("saving rendered file: %w", err)
-		}
-	}
-	return nil
-}
-
-func (mrp MultiReplacer) renderAllFiles() error {
 	// Replace values in files for each deployment
-	for i, deployment := range mrp.Deployments {
-		if err := mrp.renderDeployment(deployment); err != nil {
+	for i, deployment := range rp.Deployments {
+		if err := rp.renderDeployment(deployment); err != nil {
 			return fmt.Errorf("render deployment[%d] in %q: %w", i, deployment.Path, err)
 		}
 	}
 	return nil
 }
 
-func (mrp MultiReplacer) renderDeployment(deployment Deployment) error {
+func (rp Replacer) renderDeployment(deployment Deployment) error {
 	// Replace values in files sitting in the destination folder one-by-one
 	// (substituting values given for this deployment).
 	for _, file := range deployment.Files {
-		originalFile := path.Join(mrp.DestinationRepo.localPath(), deployment.Path, file)
-		renderedFile, err := mrp.renderFile(originalFile, deployment.Values)
+		originalFile := path.Join(rp.DestinationRepo.localPath(), deployment.Path, file)
+		renderedFile, err := rp.renderFile(originalFile, deployment.Values)
 
 		if err != nil {
 			return fmt.Errorf("render file %q: %w", originalFile, err)
@@ -111,49 +63,6 @@ func (mrp MultiReplacer) renderDeployment(deployment Deployment) error {
 	return nil
 }
 
-func (mrp MultiReplacer) renderFile(fileName string, values map[string]string) (string, error) {
-	// Open file in local repository.
-	f, err := os.Open(fileName)
-	if err != nil {
-		return "", fmt.Errorf("open file %s: %w", fileName, err)
-	}
-	defer f.Close() //nolint:errcheck
-
-	// Create temporary file.
-	tmpFile, err := os.CreateTemp("", "")
-	if err != nil {
-		return "", fmt.Errorf("creating tmp file %s: %w", tmpFile.Name(), err)
-	}
-	defer tmpFile.Close() //nolint:errcheck
-
-	w := bufio.NewWriter(tmpFile)
-
-	// Read file and replace occurances line by line.
-	reader := bufio.NewReader(f)
-	var EOF bool
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if err != io.EOF {
-				return "", fmt.Errorf("reading lines : %w", err)
-			}
-			EOF = true
-		}
-		replacedLine, err := replaceAll(line, mrp.Delimiter, values)
-		if err != nil {
-			return "", fmt.Errorf("could replace values in file (%s) line (%s): %w", fileName, line, err)
-		}
-		w.WriteString(replacedLine) // nolint:errcheck
-
-		if EOF {
-			break
-		}
-	}
-	w.Flush() // nolint:errcheck
-
-	return tmpFile.Name(), nil
-}
-
 func (rp Replacer) renderFile(fileName string, values map[string]string) (string, error) {
 	// Open file in local repository.
 	f, err := os.Open(fileName)
@@ -171,7 +80,7 @@ func (rp Replacer) renderFile(fileName string, values map[string]string) (string
 
 	w := bufio.NewWriter(tmpFile)
 
-	// Read file and replace occurances line by line.
+	// Read file and replace occurrences line by line.
 	reader := bufio.NewReader(f)
 	var EOF bool
 	for {
@@ -184,7 +93,7 @@ func (rp Replacer) renderFile(fileName string, values map[string]string) (string
 		}
 		replacedLine, err := replaceAll(line, rp.Delimiter, values)
 		if err != nil {
-			return "", fmt.Errorf("could replace values in file (%s) line (%s): %w", fileName, line, err)
+			return "", fmt.Errorf("could not replace values in file (%s) line (%s): %w", fileName, line, err)
 		}
 		w.WriteString(replacedLine) // nolint:errcheck
 

--- a/pkg/gitops/replacer.go
+++ b/pkg/gitops/replacer.go
@@ -22,12 +22,25 @@ type Replacer struct {
 	DestinationFolder string
 }
 
+// MultiReplacer replaces values in multiple deployment folders.
+type MultiReplacer struct {
+	// Delimiter to look for when rendering key-value pairs
+	Delimiter string
+	// Destination repository for rendered files.
+	DestinationRepo localRepository
+	// Deployments contains multiple deployment configurations.
+	Deployments []Deployment
+}
+
+// Ensure MultiReplacer implements AllFilesRenderer
+var _ AllFilesRenderer = (*MultiReplacer)(nil)
+
 func (rp Replacer) renderAllFiles() error {
 	// Replace values in files sitting in the destinaton folder one-by-one
 	// (substituting values given).
 	for _, file := range rp.Files {
 		originalFile := path.Join(rp.DestinationRepo.localPath(), rp.DestinationFolder, file)
-		renderedFile, err := rp.renderFile(originalFile)
+		renderedFile, err := rp.renderFile(originalFile, rp.Values)
 
 		if err != nil {
 			return fmt.Errorf("render file %q: %w", originalFile, err)
@@ -55,7 +68,50 @@ func (rp Replacer) renderAllFiles() error {
 	return nil
 }
 
-func (rp Replacer) renderFile(fileName string) (string, error) {
+func (mrp MultiReplacer) renderAllFiles() error {
+	// Replace values in files for each deployment
+	for i, deployment := range mrp.Deployments {
+		if err := mrp.renderDeployment(deployment); err != nil {
+			return fmt.Errorf("render deployment[%d] in %q: %w", i, deployment.Path, err)
+		}
+	}
+	return nil
+}
+
+func (mrp MultiReplacer) renderDeployment(deployment Deployment) error {
+	// Replace values in files sitting in the destination folder one-by-one
+	// (substituting values given for this deployment).
+	for _, file := range deployment.Files {
+		originalFile := path.Join(mrp.DestinationRepo.localPath(), deployment.Path, file)
+		renderedFile, err := mrp.renderFile(originalFile, deployment.Values)
+
+		if err != nil {
+			return fmt.Errorf("render file %q: %w", originalFile, err)
+		}
+		defer os.Remove(renderedFile) //nolint:errcheck
+
+		// the rendered / replaced file becomes the source
+		source, err := os.Open(renderedFile)
+		if err != nil {
+			return fmt.Errorf("open rendered file: %w", err)
+		}
+		defer source.Close() //nolint:errcheck
+
+		// the original file location becomes the destination
+		destination, err := os.Create(originalFile)
+		if err != nil {
+			return fmt.Errorf("open destination file: %w", err)
+		}
+
+		// write the updated file contents to the original location
+		if err := copy(source, destination); err != nil {
+			return fmt.Errorf("saving rendered file: %w", err)
+		}
+	}
+	return nil
+}
+
+func (mrp MultiReplacer) renderFile(fileName string, values map[string]string) (string, error) {
 	// Open file in local repository.
 	f, err := os.Open(fileName)
 	if err != nil {
@@ -83,7 +139,50 @@ func (rp Replacer) renderFile(fileName string) (string, error) {
 			}
 			EOF = true
 		}
-		replacedLine, err := replaceAll(line, rp.Delimiter, rp.Values)
+		replacedLine, err := replaceAll(line, mrp.Delimiter, values)
+		if err != nil {
+			return "", fmt.Errorf("could replace values in file (%s) line (%s): %w", fileName, line, err)
+		}
+		w.WriteString(replacedLine) // nolint:errcheck
+
+		if EOF {
+			break
+		}
+	}
+	w.Flush() // nolint:errcheck
+
+	return tmpFile.Name(), nil
+}
+
+func (rp Replacer) renderFile(fileName string, values map[string]string) (string, error) {
+	// Open file in local repository.
+	f, err := os.Open(fileName)
+	if err != nil {
+		return "", fmt.Errorf("open file %s: %w", fileName, err)
+	}
+	defer f.Close() //nolint:errcheck
+
+	// Create temporary file.
+	tmpFile, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", fmt.Errorf("creating tmp file %s: %w", tmpFile.Name(), err)
+	}
+	defer tmpFile.Close() //nolint:errcheck
+
+	w := bufio.NewWriter(tmpFile)
+
+	// Read file and replace occurances line by line.
+	reader := bufio.NewReader(f)
+	var EOF bool
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			if err != io.EOF {
+				return "", fmt.Errorf("reading lines : %w", err)
+			}
+			EOF = true
+		}
+		replacedLine, err := replaceAll(line, rp.Delimiter, values)
 		if err != nil {
 			return "", fmt.Errorf("could replace values in file (%s) line (%s): %w", fileName, line, err)
 		}

--- a/pkg/gitops/replacer_test.go
+++ b/pkg/gitops/replacer_test.go
@@ -180,15 +180,19 @@ DEN_LINUX_x86_SHASUM=ec509e440a0fc64f9840c8e192f5e4573da972a93f3579c527b4dae9454
 
 			replacer := Replacer{
 				Delimiter: tc.delimiter,
-				Values:    tc.values,
+				Deployments: []Deployment{
+					{
+						Path:   path.Dir(source.Name()),
+						Values: tc.values,
+						Files: []string{
+							source.Name(),
+						},
+					},
+				},
 				DestinationRepo: &localRepositoryMock{
 					localPathFunc: func() string {
 						return ""
 					},
-				},
-				DestinationFolder: path.Dir(source.Name()),
-				Files: []string{
-					source.Name(),
 				},
 			}
 
@@ -272,20 +276,24 @@ stateless-service:
 
 			replacer := Replacer{
 				Delimiter: tc.delimiter,
-				Values:    tc.values,
+				Deployments: []Deployment{
+					{
+						Path:   testFolderName,
+						Values: tc.values,
+						Files:  files,
+					},
+				},
 				DestinationRepo: &localRepositoryMock{
 					localPathFunc: func() string {
 						return ""
 					},
 				},
-				DestinationFolder: testFolderName,
-				Files:             files,
 			}
 
 			err := replacer.renderAllFiles()
 			require.NoError(t, err, "renderAllFiles")
 
-			renderedFiles, err := os.ReadDir(replacer.DestinationFolder)
+			renderedFiles, err := os.ReadDir(testFolderName)
 			require.NoError(t, err, "ReadDir")
 			for _, file := range renderedFiles {
 				b, err := os.ReadFile(path.Join(testFolderName, file.Name()))

--- a/pkg/gitops/replacer_test.go
+++ b/pkg/gitops/replacer_test.go
@@ -192,7 +192,7 @@ DEN_LINUX_x86_SHASUM=ec509e440a0fc64f9840c8e192f5e4573da972a93f3579c527b4dae9454
 				},
 			}
 
-			rendered, err := replacer.renderFile(source.Name())
+			rendered, err := replacer.renderFile(source.Name(), tc.values)
 			require.NoError(t, err, "renderFile")
 			defer os.Remove(rendered)
 

--- a/pkg/gitops/templates.go
+++ b/pkg/gitops/templates.go
@@ -12,23 +12,8 @@ type AllFilesRenderer interface {
 	renderAllFiles() error
 }
 
-// templates implements the allFilesRenderer interface.
-var _ AllFilesRenderer = (*Templates)(nil)
-
-// Templates renders a folder of templates to a local repository.
+// Templates renders a folder of templates to multiple destinations in a local repository.
 type Templates struct {
-	// Source folder of templates.
-	SourceFolder string
-	// Values to substitute into the templates.
-	Values map[string]string
-	// Destination repository for rendered files.
-	DestinationRepo localRepository
-	// Destination folder inside the repository for rendered files.
-	DestinationFolder string
-}
-
-// MultiTemplates renders a folder of templates to multiple destinations in a local repository.
-type MultiTemplates struct {
 	// Source folder of templates.
 	SourceFolder string
 	// Deployments contains multiple deployment configurations.
@@ -37,56 +22,38 @@ type MultiTemplates struct {
 	DestinationRepo localRepository
 }
 
-// Ensure MultiTemplates implements AllFilesRenderer
-var _ AllFilesRenderer = (*MultiTemplates)(nil)
+var _ AllFilesRenderer = (*Templates)(nil)
 
 func (tr Templates) renderAllFiles() error {
-	// Get all template file names from the source folder.
-	files, err := os.ReadDir(tr.SourceFolder)
-	if err != nil {
-		return fmt.Errorf("read files in %q: %w", tr.SourceFolder, err)
-	}
-
-	// Render templates one-by-one to the destinaton folder
-	// (substituting values given).
-	for _, file := range files {
-		if err := tr.renderFile(file.Name()); err != nil {
-			return fmt.Errorf("render file %q: %w", file.Name(), err)
-		}
-	}
-	return nil
-}
-
-func (mtr MultiTemplates) renderAllFiles() error {
 	// Render templates for each deployment
-	for i, deployment := range mtr.Deployments {
-		if err := mtr.renderDeployment(deployment); err != nil {
+	for i, deployment := range tr.Deployments {
+		if err := tr.renderDeployment(deployment); err != nil {
 			return fmt.Errorf("render deployment[%d] to %q: %w", i, deployment.Path, err)
 		}
 	}
 	return nil
 }
 
-func (mtr MultiTemplates) renderDeployment(deployment Deployment) error {
+func (tr Templates) renderDeployment(deployment Deployment) error {
 	// Get all template file names from the source folder.
-	files, err := os.ReadDir(mtr.SourceFolder)
+	files, err := os.ReadDir(tr.SourceFolder)
 	if err != nil {
-		return fmt.Errorf("read files in %q: %w", mtr.SourceFolder, err)
+		return fmt.Errorf("read files in %q: %w", tr.SourceFolder, err)
 	}
 
 	// Render templates one-by-one to the destination folder
 	// (substituting values given for this deployment).
 	for _, file := range files {
-		if err := mtr.renderFile(file.Name(), deployment); err != nil {
+		if err := tr.renderFile(file.Name(), deployment); err != nil {
 			return fmt.Errorf("render file %q: %w", file.Name(), err)
 		}
 	}
 	return nil
 }
 
-func (mtr MultiTemplates) renderFile(fileName string, deployment Deployment) error {
+func (tr Templates) renderFile(fileName string, deployment Deployment) error {
 	// Parse template.
-	sourceFilePath := filepath.Join(mtr.SourceFolder, fileName)
+	sourceFilePath := filepath.Join(tr.SourceFolder, fileName)
 	t, err := template.ParseFiles(sourceFilePath)
 	if err != nil {
 		return fmt.Errorf("parse template %q: %w", sourceFilePath, err)
@@ -94,7 +61,7 @@ func (mtr MultiTemplates) renderFile(fileName string, deployment Deployment) err
 
 	// Create a file for the rendered template.
 	destinationFilePath := filepath.Join(
-		mtr.DestinationRepo.localPath(), deployment.Path, fileName)
+		tr.DestinationRepo.localPath(), deployment.Path, fileName)
 
 	// Ensure the destination directory exists
 	destinationDir := filepath.Dir(destinationFilePath)
@@ -110,29 +77,6 @@ func (mtr MultiTemplates) renderFile(fileName string, deployment Deployment) err
 
 	// Render the template to the previously created file.
 	if err := t.Option("missingkey=error").Execute(f, deployment.Values); err != nil {
-		return fmt.Errorf("execute template %q: %w", sourceFilePath, err)
-	}
-	return nil
-}
-
-func (tr Templates) renderFile(fileName string) error {
-	// Parse template.
-	sourceFilePath := filepath.Join(tr.SourceFolder, fileName)
-	t, err := template.ParseFiles(sourceFilePath)
-	if err != nil {
-		return fmt.Errorf("parse template %q: %w", sourceFilePath, err)
-	}
-
-	// Create a file for the rendered template.
-	destinationFilePath := filepath.Join(
-		tr.DestinationRepo.localPath(), tr.DestinationFolder, fileName)
-	f, err := os.Create(destinationFilePath)
-	if err != nil {
-		return fmt.Errorf("create destination file: %w", err)
-	}
-
-	// Render the template to the previously created file.
-	if err := t.Option("missingkey=error").Execute(f, tr.Values); err != nil {
 		return fmt.Errorf("execute template %q: %w", sourceFilePath, err)
 	}
 	return nil

--- a/pkg/gitops/templates.go
+++ b/pkg/gitops/templates.go
@@ -27,6 +27,19 @@ type Templates struct {
 	DestinationFolder string
 }
 
+// MultiTemplates renders a folder of templates to multiple destinations in a local repository.
+type MultiTemplates struct {
+	// Source folder of templates.
+	SourceFolder string
+	// Deployments contains multiple deployment configurations.
+	Deployments []Deployment
+	// Destination repository for rendered files.
+	DestinationRepo localRepository
+}
+
+// Ensure MultiTemplates implements AllFilesRenderer
+var _ AllFilesRenderer = (*MultiTemplates)(nil)
+
 func (tr Templates) renderAllFiles() error {
 	// Get all template file names from the source folder.
 	files, err := os.ReadDir(tr.SourceFolder)
@@ -40,6 +53,64 @@ func (tr Templates) renderAllFiles() error {
 		if err := tr.renderFile(file.Name()); err != nil {
 			return fmt.Errorf("render file %q: %w", file.Name(), err)
 		}
+	}
+	return nil
+}
+
+func (mtr MultiTemplates) renderAllFiles() error {
+	// Render templates for each deployment
+	for i, deployment := range mtr.Deployments {
+		if err := mtr.renderDeployment(deployment); err != nil {
+			return fmt.Errorf("render deployment[%d] to %q: %w", i, deployment.Path, err)
+		}
+	}
+	return nil
+}
+
+func (mtr MultiTemplates) renderDeployment(deployment Deployment) error {
+	// Get all template file names from the source folder.
+	files, err := os.ReadDir(mtr.SourceFolder)
+	if err != nil {
+		return fmt.Errorf("read files in %q: %w", mtr.SourceFolder, err)
+	}
+
+	// Render templates one-by-one to the destination folder
+	// (substituting values given for this deployment).
+	for _, file := range files {
+		if err := mtr.renderFile(file.Name(), deployment); err != nil {
+			return fmt.Errorf("render file %q: %w", file.Name(), err)
+		}
+	}
+	return nil
+}
+
+func (mtr MultiTemplates) renderFile(fileName string, deployment Deployment) error {
+	// Parse template.
+	sourceFilePath := filepath.Join(mtr.SourceFolder, fileName)
+	t, err := template.ParseFiles(sourceFilePath)
+	if err != nil {
+		return fmt.Errorf("parse template %q: %w", sourceFilePath, err)
+	}
+
+	// Create a file for the rendered template.
+	destinationFilePath := filepath.Join(
+		mtr.DestinationRepo.localPath(), deployment.Path, fileName)
+
+	// Ensure the destination directory exists
+	destinationDir := filepath.Dir(destinationFilePath)
+	if err := os.MkdirAll(destinationDir, 0755); err != nil {
+		return fmt.Errorf("create destination directory: %w", err)
+	}
+
+	f, err := os.Create(destinationFilePath)
+	if err != nil {
+		return fmt.Errorf("create destination file: %w", err)
+	}
+	defer f.Close()
+
+	// Render the template to the previously created file.
+	if err := t.Option("missingkey=error").Execute(f, deployment.Values); err != nil {
+		return fmt.Errorf("execute template %q: %w", sourceFilePath, err)
 	}
 	return nil
 }

--- a/pkg/gitops/templates_test.go
+++ b/pkg/gitops/templates_test.go
@@ -163,13 +163,17 @@ func TestRenderAllFiles(t *testing.T) {
 			// Run Templates.renderAllFiles.
 			tr := Templates{
 				SourceFolder: templatesDir,
-				Values:       tc.values,
+				Deployments: []Deployment{
+					{
+						Path:   tc.folder,
+						Values: tc.values,
+					},
+				},
 				DestinationRepo: &localRepositoryMock{
 					localPathFunc: func() string {
 						return renderRepo
 					},
 				},
-				DestinationFolder: tc.folder,
 			}
 
 			// Assert for error.

--- a/step.yml
+++ b/step.yml
@@ -37,21 +37,15 @@ inputs:
   opts:
     title: Github HTTPS URL of the repository to deploy to
     is_required: true
-- deploy_path: ""
-  opts:
-    title: Path to place rendered templates inside the repository
-    description: |-
-      Deprecated: Use 'deployments' input for multiple deployments.
-      Path to place rendered templates inside the repository.
-      This is kept for backwards compatibility.
 - deployments: ""
   opts:
-    title: Multiple deployment configurations
+    title: Deployment configurations
+    is_required: true
     description: |-
-      Configure multiple deployments to update in a single commit.
-      Each deployment can have its own path and values.
+      Configure one or more deployments to update in a single commit.
+      Each deployment must have a path and values. In replacer mode, files must also be specified.
 
-      For example:
+      For template mode:
 
       ```yaml
       - path: package-foo
@@ -64,7 +58,15 @@ inputs:
           tag: v1.0.0
       ```
 
-      If specified, this will override 'deploy_path' and 'values' inputs.
+      For replacer mode (include files to scan):
+
+      ```yaml
+      - path: my-service
+        files:
+          - config.yaml
+        values:
+          us.gcr.io/my-project/my-service: v1.0.0
+      ```
 - deploy_token: $DEPLOY_TOKEN
   opts:
     title: Personal Access Token to interact with Github API
@@ -77,27 +79,18 @@ inputs:
 - deploy_branch: "master"
   opts:
     title: Branch of the repository to deploy to
+    is_required: true
 - commit_message: bitrise ci integration
   opts:
     title: Commit message of pushed changes
+    is_required: true
 - templates_folder_path: deployments/helm
   opts:
     title: Path to Go templates folder
     category: Templates
-- values: null
-  opts:
-    title: Input values for the Go template files in YAML format
     description: |-
-      Input values for the Go template files as key-value pairs in YAML format.
-
-      For example:
-
-      ```
-      my-key1: my value 1
-      my-key2: my value 2
-      ```
-
-    category: Templates
+      Path to the folder containing Go template files.
+      Required in template mode (when replacer_mode is false).
 - pull_request: false
   opts:
     title: Open a pull request
@@ -120,10 +113,11 @@ inputs:
   opts:
     title: Key-value matching mode
     category: Replacer mode
+    is_required: true
     description: |
       There are situations when simple templating is not sufficient. 
       Replacer mode enables matching & replacing values based on a key+delimiter combination,
-      across multiple files.
+      across multiple files specified in each deployment's 'files' field.
     value_options:
     - "true"
     - "false"
@@ -134,13 +128,6 @@ inputs:
     description: |
       Indicates the delimiter between key and value.
       For example in "key=value", "=" is the delimiter. 
-      Required when "Replacer mode" is enabled.
-- files:
-  opts:
-    title: Files
-    category: Replacer mode
-    description: |
-      List of files to scan for matching key-value pairs.
       Required when "Replacer mode" is enabled.
 
 outputs:

--- a/step.yml
+++ b/step.yml
@@ -40,6 +40,31 @@ inputs:
 - deploy_path: ""
   opts:
     title: Path to place rendered templates inside the repository
+    description: |-
+      Deprecated: Use 'deployments' input for multiple deployments.
+      Path to place rendered templates inside the repository.
+      This is kept for backwards compatibility.
+- deployments: ""
+  opts:
+    title: Multiple deployment configurations
+    description: |-
+      Configure multiple deployments to update in a single commit.
+      Each deployment can have its own path and values.
+
+      For example:
+
+      ```yaml
+      - path: package-foo
+        values:
+          repository: example.com/repo/package-foo
+          tag: v1.0.0
+      - path: package-bar
+        values:
+          repository: example.com/repo/package-bar
+          tag: v1.0.0
+      ```
+
+      If specified, this will override 'deploy_path' and 'values' inputs.
 - deploy_token: $DEPLOY_TOKEN
   opts:
     title: Personal Access Token to interact with Github API


### PR DESCRIPTION
Add support for multiple deployments in a single commit.

## Breaking Changes

This is a **breaking change** release with no backwards compatibility:

**Before:**
```yaml
- deploy_path: my-service
- values: |
    repository: example.com/repo/service
    tag: v1.0.0
```

**After:**
```yaml
- deployments: |
    - path: my-service
      values:
        repository: example.com/repo/service
        tag: v1.0.0
```

## Demo

Below is an example of how the our production deployment workflow appears after this update.

**After the change:**
<img width="973" height="174" alt="deploy_production_new" src="https://github.com/user-attachments/assets/3d5a6b1e-f130-4188-ada4-ca10272e2abc" />

**Before the change:**
<img width="2025" height="3458" alt="deploy_production_old" src="https://github.com/user-attachments/assets/f68b453d-60a3-46ea-98a1-2d9e69681d32" />

